### PR TITLE
Declaration oprimized for `oled_cool_lines`

### DIFF
--- a/Firmware/code.py
+++ b/Firmware/code.py
@@ -49,10 +49,15 @@ for oled in oleds:
     oled.rotation = 2
 
 try:
-    oled_cool_lines = [['', '', '', '', '', '', '', ''],
-                       ['', '', '', '', '', '', '', ''],
-                       ['', '', '', '', '', '', '', '']]
+    oled_cool_lines = [['']*8 for _ in range(3)]
 
+    '''
+    equal to
+    [['', '', '', '', '', '', '', ''],
+     ['', '', '', '', '', '', '', ''],
+     ['', '', '', '', '', '', '', '']]
+    '''
+    
     def cool_ass_parsing_visualizer(text):
         for oled in oleds:
             oled.fill(0)


### PR DESCRIPTION
A better approach declaring the empty lists with a specified size.